### PR TITLE
Pin wrangler to 4.83.0 to fix UTF-8 deploy failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,4 +21,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.83.0"
           command: pages deploy dist --project-name matt-site


### PR DESCRIPTION
## Summary
- Cloudflare Pages API rejected the last deploy ([run 24535790855](https://github.com/mcotse/mcotse.github.io/actions/runs/24535790855)) with `Invalid commit message, it must be a valid UTF-8 string. [code: 8000111]`.
- `cloudflare/wrangler-action@v3` was falling back to installing wrangler 3.90.0, which has a known encoding issue when passing commit metadata to the Pages API.
- Pinning `wranglerVersion: "4.83.0"` (the version the action initially probed for) should resolve it.

## Test plan
- [ ] Merge triggers Deploy workflow
- [ ] Wrangler 4.83.0 installs
- [ ] `pages deploy dist --project-name matt-site` succeeds
- [ ] Site reflects latest main